### PR TITLE
暂存

### DIFF
--- a/2002/9-10.md
+++ b/2002/9-10.md
@@ -1,16 +1,17 @@
 # FreeBSD 2002 年 9-10 月状态报告
 
-原文链接：[FreeBSD 2002 年 9-10 月状态报告](https://www.freebsd.org/status/report-2002-09-2002-10.html)
+- 原文链接：[FreeBSD 2002 年 9-10 月状态报告](https://www.freebsd.org/status/report-2002-09-2002-10.html)
+- 作者：FreeBSD 项目
 
-# 介绍
+FreeBSD 项目又一段忙碌的时光带来了显著成熟和功能完善的 5.0-CURRENT 分支。而且时机恰到好处，因为在你阅读下份状态报告时，我们期望你在桌面正上运行着 FreeBSD 5.0！在过去的两个月，我们见证了 sparc64 升级为一级架构（完全支持）状态、高质量存储加密模块的集成、硬件加速 IPsec 支持的提交、通用“设备守护进程”的加入，用于处理硬件连接/断开事件，取代了早期的单一用途和总线特定守护进程，RAIDFrame 的提交，以及 TrustedBSD 工作的成熟度提升。我们还见证了 4.x 分支的另一版成功发布，即 4.7-RELEASE，这将继续作为生产支持平台，而 5.X 则正逐步到位。
 
-FreeBSD 项目的又一段忙碌的时光带来了 5.0-CURRENT 分支的显著成熟和功能完善。而且时机恰到好处，因为在你阅读下个状态报告时，我们希望你已经在桌面上运行着 FreeBSD 5.0！在过去的两个月里，我们见证了 sparc64 升级为 Tier 1（完全支持）状态、高质量存储加密模块的集成、硬件加速 IPsec 支持的提交、通用“设备守护进程”的加入，用于处理硬件连接/断开事件，取代了早期的单一用途和总线特定守护进程，RAIDFrame 的提交，以及 TrustedBSD 工作的成熟度提升。我们还见证了 4.x 分支的另一版成功发布，即 4.7-RELEASE，这将继续作为生产支持平台，而 5.X 则正逐步到位。
-
-在接下来的两个月里，FreeBSD 项目将几乎完全专注于确保 5.0 的成功：提高系统的稳定性和性能，并增加能够在 5.0 上构建和运行的应用程序池。在你阅读此报告时，发布工程团队已经宣布 5.0 的代码冻结，并发布了 DP2。接下来会有一系列的发布候选版本（RC），然后是正式发布。如果你有兴趣参与测试过程，请帮忙——一台备用计算机和一份烧录到 CD 上的 DP 和 RC ISO 镜像将产生影响。预发布版本的操作系统通常会有一些警告提示！你也许还会对发布工程团队制作的早期采用者指南感兴趣，帮助你判断何时适合从 4.x 分支过渡到 5.x 分支。
+在接下来的两个月里，FreeBSD 项目将几乎完全专注于确保 5.0 的成功：提高系统的稳定性和性能，并增加能够在 5.0 上构建和运行的应用程序池。在你阅读此报告时，发布工程团队已宣布 5.0 的代码冻结，并发布了开发者预览版 2。接下来会有一系列的发布候选版本（RC），然后是正式发布。如果你有兴趣参与测试过程，请帮忙——一台备用计算机和一份烧录到 CD 上的开发者预览镜像和 RC ISO 镜像可产生作用。预发布版本的操作系统通常会有一些警告提示！你也许还会对发布工程团队制作的早期尝鲜者指南感兴趣，帮助你判断何时适合从 4.x 分支过渡到 5.x 分支。
 
 感谢，
 
-Robert Watson, Scott Long
+Robert Watson
+
+Scott Long
 
 ## [FreeBSD 的蓝牙栈（Netgraph 实现）](<https://www.freebsd.org/status/report-2002-09-2002-10.html#Bluetooth-stack-for-FreeBSD-(Netgraph-implementation)>)
 
@@ -24,13 +25,13 @@ Robert Watson, Scott Long
 
 联系人：Maksim Yevmenkin <[m_evmenkin@yahoo.com](mailto:m_evmenkin@yahoo.com)>
 
-我很高兴地宣布，现已可以下载另一个工程版发布，网址为 [http://www.geocities.com/m_evmenkin/ngbt-fbsd-20021104.tar.gz](http://www.geocities.com/m_evmenkin/ngbt-fbsd-20021104.tar.gz)
+我很高兴地宣布，现在可以下载另外的工程版发行版，网址为 [http://www.geocities.com/m_evmenkin/ngbt-fbsd-20021104.tar.gz](http://www.geocities.com/m_evmenkin/ngbt-fbsd-20021104.tar.gz)
 
-此版本包括了一些小的错误修复和新的 Port OpenOBEX 库。快照包含对 H4 UART 和 H2 USB 传输层的支持，主机控制器接口（HCI），链路层控制与适配协议（L2CAP）以及蓝牙套接字层。它还带有一些用户空间实用程序，可以用来配置和测试蓝牙设备。此外，还有几个手册页。
+此版本包括了一些小的错误修复和新的 Port OpenOBEX 库。快照包含对 H4 UART 和 H2 USB 传输层的支持，主机控制器接口（HCI），链路层控制与适配协议（L2CAP）以及蓝牙套接字层。它还带有一些用户空间实用程序，可以用来配置和测试蓝牙设备。此外，还有若干手册页。
 
-Port 服务发现协议（SDP）已更新至版本 0.8（从 BlueZ-sdp-0.8 移植）。大多数 RFCOMM 问题已解决，现在 rfcommd 可以与 Windows（3COM、Xircom 和 Widcomm）和 Linux 栈兼容。
+Port 服务发现协议（SDP）已更新至版本 0.8（从 BlueZ-sdp-0.8 移植）。大多数 RFCOMM 问题已解决，现在 rfcommd 能与 Windows（3COM、Xircom 和 Widcomm）和 Linux 栈兼容。
 
-新增支持的 USB 设备 - EPoX BT-DG02 加密狗。我还收到关于 Mitsumi USB 加密狗和 C413S 蓝牙手机的成功报告（L2CAP 和 SDP 正常工作，等待 RFCOMM 报告）。
+新增支持的 USB 设备 - EPoX BT-DG02 加密狗。我还收到了有关 Mitsumi USB 加密狗和 C413S 蓝牙手机的成功报告（L2CAP 和 SDP 正常工作，等待 RFCOMM 报告）。
 
 我目前正在开发 OBEX 服务器（推送和文件传输协议），它将基于 OpenOBEX 库（包括在快照中）。
 
@@ -42,12 +43,12 @@ Port 服务发现协议（SDP）已更新至版本 0.8（从 BlueZ-sdp-0.8 移�
 
 联系人：Gregory Shapiro <[gshapiro@FreeBSD.org](mailto:gshapiro@FreeBSD.org)>
 
-BSDCon 2003 项目委员会邀请你提交原创和创新的论文，内容涉及与 BSD 衍生系统及开源世界相关的话题。感兴趣的主题包括但不限于：
+2003 BSDCon 项目委员会邀请你提交原创和创新的论文，内容涉及与 BSD 衍生系统及开源世界相关的话题。感兴趣的主题包括但不限于：
 
 - 嵌入式 BSD 应用开发与部署
 - 使用 BSD 系统的实际经验
 - 在混合操作系统环境中使用 BSD
-- 与非 BSD 操作系统的比较；技术、实际、许可证（GPL 与 BSD）
+- 与非 BSD 操作系统的比较；技术、实际、许可协议（GPL 与 BSD）
 - 跟踪非 BSD 系统上的开源开发
 - BSD 桌面应用
 - I/O 子系统和设备驱动程序开发
@@ -59,7 +60,7 @@ BSDCon 2003 项目委员会邀请你提交原创和创新的论文，内容涉�
 - 系统管理
 - BSD 的未来
 
-提交的扩展摘要截止日期为 2003 年 4 月 1 日。在提交之前，请务必查看扩展摘要的要求。选择将基于书面提交的质量以及工作是否对社区有吸引力。
+提交的详细摘要截止日期为 2003 年 4 月 1 日。在提交之前，请务必查看详细摘要的要求。选择将基于书面提交的质量以及工作是否对社区有吸引力。
 
 我们期待收到你的投稿！
 
@@ -75,23 +76,23 @@ BSDCon 2003 项目委员会邀请你提交原创和创新的论文，内容涉�
 
 2002 年 10 月 10 日标志着我们项目的一周年纪念。在这段时间里，我们在 FreeBSD 的标准合规性方面取得了显著进展。FreeBSD 5.0-RELEASE 将是我们辛勤工作的展示平台。我们希望我们的不懈努力对 FreeBSD 和那些维护或考虑将其软件移植到 FreeBSD 的软件供应商产生了积极的影响。
 
-在 API 方面，添加了 `_Exit(3)`（是 `_exit(2)` 的别名），sysconf(3) 已更新为符合 POSIX.1-2001 标准，并且一些 glob(3) 的新增功能已经 MFC（合并到主分支）。insque()、lsearch() 和 remque() 函数家族已经重新实现并从 libcompat 移至 libc。实现了多个宽字符函数，包括所有 printf() 和 scanf() 变体。最后，向 printf(3) 添加了对宽字符格式类型（`%C`、`%S`、`%lc`、`%ls`）的支持。
+在 API 方面，添加了 `_Exit(3)`（是 `_exit(2)` 的别名），sysconf(3) 现已遵守 POSIX.1-2001 标准，一些 glob(3) 的新增功能也已经 MFC（合并到主分支）。已经重新实现了函数家族 insque()、lsearch() 和 remque()，还从 libcompat 移至 libc。实现了多个宽字符函数，如所有 printf() 和 scanf() 变体。最后，向 printf(3) 添加了对宽字符格式类型（`%C`、`%S`、`%lc`、`%ls`）的支持。
 
-在实用程序合规性方面，getconf(1) 的合规性得到了更新，c99(1)（c89(1) 的新版本）已实现，cd(1) 和 command(1) 的更改已 MFC。
+在实用程序合规性方面，getconf(1) 的合规性得到了改进，已实现 c99(1)（c89(1) 的新版本），对 cd(1) 和 command(1) 的更改已 MFC。
 
-近 20 个头文件已更新以符合适用标准。剩余标准头文件的合规性问题已不多。由于 5.0-RELEASE 的准备工作，这一领域的工作进展放缓。
+近 20 个头文件现已符合适用标准。剩余标准头文件的合规性问题已不多。由于 5.0-RELEASE 的准备工作，这一领域的工作进展放缓。
 
 ## [DEVD 状态报告](https://www.freebsd.org/status/report-2002-09-2002-10.html#DEVD-Status-Report)
 
 联系人：Warner Losh <[imp@FreeBSD.org](mailto:imp@FreeBSD.org)>
 
-DEVD 已经集成到 FreeBSD 的当前版本中。它是在一个不完全的状态下集成的。然而，在目前的状态下，它仍然能处理一些简单的任务，比如在插入 SCSI pcmcia 卡时运行 `camcontrol rescan`，或在插入以太网卡时运行 `/etc/pccard_ether`。更复杂的正则表达式匹配功能尚未完成。Devd 只处理设备的到达和离开，但尚未处理未知设备。此外，除了监听设备事件之外，还希望 /dev/devctl 能够允许对设备树进行一些直接控制。
+已将 DEVD 集成到当前版本的 FreeBSD 中。当前集成状态仍不完全。然而，在目前的状态下，它仍然能处理一些简单的任务，比如在插入 SCSI pcmcia 卡时运行 `camcontrol rescan`，或在插入以太网卡时运行 `/etc/pccard_ether`。更复杂的正则表达式匹配功能尚未完成。Devd 只处理设备的到达和离开，但尚未处理未知设备。此外，除了监听设备事件之外，还希望 `/dev/devctl` 能够对设备树进行一些直接控制。
 
 ## [Fast IPsec 状态](https://www.freebsd.org/status/report-2002-09-2002-10.html#Fast-IPsec-Status)
 
 联系人：Sam Leffler <[sam@FreeBSD.org](mailto:sam@FreeBSD.org)>
 
-该项目的主要目标是修改 IPsec 协议，以使用从 OpenBSD 导入的内核级加密子系统（详见其他地方）。次要目标是对 IPsec 协议进行性能调优。
+该项目的主要目标是修改 IPsec 协议，以使用从 OpenBSD 引入的内核级加密子系统（详见其他地方）。次要目标是对 IPsec 协议进行性能调优。
 
 此项工作已提交至 -current。要配置使用它，请在系统配置文件中指定选项 `FAST_IPSEC`。目前，仅支持 IPv4。
 


### PR DESCRIPTION
## Sourcery 总结

润色 FreeBSD 2002 年 9 月至 10 月状态报告的中文译文，通过改进术语、格式和措辞，以提高清晰度和一致性。

文档：
- 添加作者元数据，并将贡献者姓名重新放置在原始链接下方
- 更新翻译术语（例如，将 DP2 译为“开发者预览版2”，以及“早期尝鲜者指南”等）
- 统一各章节措辞以保持一致性（例如，“若干手册页”和“详细摘要”）
- 润色措辞和语法，以提高清晰度
- 清理标题和链接中的格式和空白

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

润色 FreeBSD 2002 年 9 月至 10 月状态报告的中文翻译，以提高其清晰度、一致性和完整性

文档：
- 添加作者元数据并调整贡献者名称的位置
- 更新翻译术语（例如，将 DP2 翻译为“开发者预览版 2”并重命名早期采用者指南）
- 规范各章节的措辞（例如，“若干手册页”和“详细摘要”）
- 润色措辞和语法以提高可读性
- 清理标题和链接中的格式和空白

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Polish the Chinese translation of the FreeBSD 2002 Sep–Oct Status Report to improve clarity, consistency, and completeness

Documentation:
- Add author metadata and reposition contributor names
- Update translation terminology (e.g. translate DP2 as “开发者预览版 2” and rename the early adopter guide
- Standardize phrasing across sections (e.g. “若干手册页” and “详细摘要”)
- Refine wording and grammar for better readability
- Clean up formatting and whitespace in headings and links

</details>

</details>